### PR TITLE
Add English pacenotes for 'Scotland - Newhouse Bridge'

### DIFF
--- a/Scotland-dr2/newhouse-bridge-en.md
+++ b/Scotland-dr2/newhouse-bridge-en.md
@@ -1,7 +1,6 @@
 ## Pacenotes
 
 ```txt
-
 start 6L<Xlg
 ! slowin turn 1R uphill <
 4R.Vlg>3.Xlg keepin >/smCr into

--- a/Scotland-dr2/newhouse-bridge-en.md
+++ b/Scotland-dr2/newhouse-bridge-en.md
@@ -1,0 +1,119 @@
+## Pacenotes
+
+```txt
+
+start 6L<Xlg
+! slowin turn 1R uphill <
+4R.Vlg>3.Xlg keepin >/smCr into
+3L> +keepR into 3L.Vlg> +
+4R.Vlg> (ditch outside) into
+4L 40 slowin 3R then
+turn SqR DC into
+6L.lg 130 5L/bmps 70
+4R.lg</Cr past Jct + > keepin
+50 short 5L<60/dblCr +
+6L.lg/dip slowin 40 5L>3 100
+deceptive 4L.lg/Cr>
+50 5R> into 5L
+! > narrow short 3R +
+6L.Vlg>3.lg 40
+1R lg DC (rocks inside)
+30 4L/Cr 50
+60 keepL/smCr into 3L/dip 90
+3L.lg DC (rocks inside)
+80/bmpyCrs short6L into
+6R>4/Cr+Vlg 50
+keepR/Jmp into 6R into
+late 5L/Cr DC then
+keepR/Jmp 70
+slowin 4R/Cr > sudden
+3L DC Vlg (rocks inside)
+40 deceptive 3R>/Cr into
+3L into 4R
+4L past Jct into
+slow 3R.Vlg (ditch outside) +
+slowin 4R into
+turn sudden SqL 50
+open HpR DC (rocks inside) into
+4L> +6R into
+5L/CrVlg into
+! 2R + 3L>2
+2R.Vlg DC (rocks inside) +
+3L/Cr 60 downhill
+3L.lg into 6R.Xlg
+! > 3 +
+4L.lg<> into
+4R to keepR/Jct into
+3L into slowin
+! 5R.lg> turn 1.Xlg +
+3L.lg></smCr
+60 2R<lg + 2L.lg<
+6L + lgCr + sudden 4L +
+3R slowin 80
+4L.lg 40 turn early 1L>
+90 keepM/Cr + stayM/60 to
+keepM/Jmp 60
+5L>3.Xlg 70
+smCr into 3R>
+70 early 4R/Cr
+110 downhill slowin
+3R.lg> past Jct DC +
+5L.lg> keepin/Cr into
+short 5R stayM/190 slowin
+6L + logs into 6R 40
+! 3L> keepin into
+short 6R + 4L + 6R 60
+3L keepin lg 40
+3R.lg< keepR 80
+6L/bmps into
+FR 70 keepM/Jmp 60
+! 4L slowin 60
+2R>1.Vlg> DC +
+keepM/smCr into fast 3L
+50 3L.lg> keepin into
+4L.lg + 4R<> past Jct
+! deceptive 3R>/Cr +
+1L.lg keepin into
+5R 70 6R/lgCr>
+100 past logs
+6L XXlg/Cr 130
+keepM/Jmp 80 past layby
+FL 60 4R 50 6L 50
+keepM/bgBmpJmp 60
+! 6R.lg> short 2 into
+2L.Xlg<> + 6R< 50
+3R> keepin to keepL/90
+deceptive 4R>/Cr
+! 6L.Vlg>HpL.Xlg> +
+4R.lg 50
+! short 3L/Cr into
+unseen HpR.Xlg< to
+keepM/smCr into
+3L< 140 keepR/Jmp +
+slowin 6L DC to
+5R>4/Cr 40 into 
+5L/Cr<> 3L.lg/Cr +
+FR/bmp+dip
+! 70 turn 3L> DC
+4R 40 5R.Xlg
+80 6R into
+4L DC >lg 100 to
+keepM/120 6L>/Cr into
+6R.lg 50 FR/smCr 70
+4R/Cr<lg to keepM/Cr +
+FL 50 past logs 160
+! Jmp into short 3L DC 50
+4L> 60 6L/CrVlg
+! > into 2R 1L.lg DC
+<3.Vlg>+ end + keepR into
+4L< to keepM/lgCr 70
+6R/dip< keepM/Jmp
+80 FR into 6L.Xlg< 150
+keepM/Jmp 60 6L< 60
+keepM/Cr into short 6L
+! slowin 100 downhill smCr +
+2R> + turn SqR DC into
+6L<> 5L/finish Xlg>3 50 
+ 
+stop
+```


### PR DESCRIPTION
Added pacenotes according to Jemba system.
Abbreviation inspiration taken from the Jemba website:
https://www.jemba.se/notesUSA.htm

Formatting inspiration taken from the Targa NZ website
https://targa.nz/wp-content/uploads/2020/02/Rally-Sprint-Safety-Notes.pdf

I've added periods between the corner grade+direction and the duration to avoid potential confusion e.g. 5Llg becomes 5L.lg with a period.
Adding the duration before the grade+corner (E.g. lg5L) also avoids the confusion, but doesn't align with how the co-driver makes the majority of calls.